### PR TITLE
Adds Services#index

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -269,6 +271,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,0 +1,2 @@
+class ServicesController < ApplicationController
+end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,2 +1,8 @@
 class ServicesController < ApplicationController
+  def index
+
+  end
+
+  def new
+  end
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,6 +1,6 @@
 class ServicesController < ApplicationController
   def index
-
+    @services = Service.all
   end
 
   def new

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,0 +1,11 @@
+
+<h1>All Categories</h1>
+<p>This page currently shows all services of all categories</p>
+
+<% @services.each do |service| %>
+  <%= service.title %>
+  <%= service.description %>
+  <%= service.price %>
+  <%= service.delivery_time %>
+  <%= service.category %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+
+  resources :services, only: [:new]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
 
-  resources :services, only: [:new]
+  resources :services, only: %i[index new]
 end

--- a/test/controllers/services_controller_test.rb
+++ b/test/controllers/services_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ServicesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Feature: Index for Services model

Creates the Services controller and the route for service#index. Adds an instance variable (@services) in the services controller to allow the display of all services in the services index. 

- Currently not using .container or .card for index.