### PR TITLE
adds cloudinary for active storage in production environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
# Description
changes :local to :cloudinary for active storage in production environment in (production.rb file)

​
Fixes # (issue) To seed database with cloudinary images on Heroku
​

## Type of change

​
Please delete options that are not relevant.
​

- [ ] Bug fix (non-breaking change which fixes an issue)

      ​

# How Has This Been Tested?
Can't test it on heroku until merged with master to push to heroku master
​
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
​

- [ ] Screenshot A
- [ ] Screenshot B
      ​

# Checklist:

​


- [ ] I have performed a self-review of my code


