### PR TITLE
Add Homepage for Visitors

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,0 +1,20 @@
+.banner {
+  background-size: cover;
+  background-position: center;
+  padding: 150px 0;
+}
+
+.banner h1 {
+  margin: 0;
+  color: white;
+  text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
+  font-size: 32px;
+  font-weight: bold;
+}
+
+.banner p {
+  font-size: 20px;
+  color: white;
+  opacity: .7;
+  text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
+}

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,15 +1,17 @@
 .banner {
   background-size: cover;
   background-position: center;
-  padding: 150px 0;
+  padding: 120px 0;
 }
 
 .banner h1 {
   margin: 0;
   color: white;
   text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
-  font-size: 32px;
+  font-size: 48px;
   font-weight: bold;
+  margin-bottom: 1.5rem;
+  width: 600px;
 }
 
 .banner p {
@@ -17,4 +19,8 @@
   color: white;
   opacity: .7;
   text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
+}
+
+.banner-container {
+  margin: 100px;
 }

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -1,6 +1,7 @@
 // Import your components CSS files here.
 @import "alert";
 @import "avatar";
+@import "banner";
 @import "button";
 @import 'card-profile';
 @import "container";

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,1 +1,27 @@
 // Specific CSS for your home-page
+
+.trusted-by-wrapper {
+  background-color: $light-gray;
+}
+
+.trusted-by {
+  width: 800px;
+  margin: 0 auto;
+  padding: 1.2rem 0;
+  color: #B5B6BA;
+}
+
+.trusted-by > ul {
+  display: inline;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  white-space:nowrap;
+}
+
+.trusted-by > ul > li {
+  display: inline;
+  margin: 0 0 0 3rem;
+  padding: 0;
+}

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -130,20 +130,22 @@ h2 {
 .category-list {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   list-style-type: none;
-  margin: 0 auto;
-  padding: 0 auto;
+  margin: 0;
+  padding: 0;
 }
 
 .category-list-item {
   display: inline-block;
-  margin: 3.5rem;
+  margin: 2.2rem;
 }
 
 .category-list-item a {
   color: black;
   text-decoration: none;
   font-size: 1rem;
+  width: 180px;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,4 +1,9 @@
 // Specific CSS for your home-page
+h2 {
+  font-size: 2.2rem;
+  font-weight: 600;
+}
+
 .home-container {
   padding: 6rem;
 }

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -72,3 +72,56 @@ h2 {
 .category-card > h3 > small {
   font-size: 1rem;
 }
+
+// Style for Proposition section.
+.proposition-section {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.proposition-card {
+  width: 35%;
+}
+
+.proposition-card h3 {
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
+.proposition-card > h3 > span {
+  font-size: 1.4rem;
+  margin-right: 0.4rem;
+  color: gray;
+}
+
+.proposition-card p {
+  font-size: 1.1rem;
+  margin-bottom: 1.5rem;
+  color: gray;
+}
+
+.proposition-video {
+  aspect-ratio: 16 / 10;
+  width: 55%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.video-btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+  color: white;
+  background-color: rgba(0, 0, 0, 0.5);
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  font-size: 35px;
+}
+
+.video-btn:hover {
+  color: white;
+}

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -125,3 +125,49 @@ h2 {
 .video-btn:hover {
   color: white;
 }
+
+// Style for category list section
+.category-list {
+  display: inline-block;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.category-list-item {
+  display: inline;
+  margin: 2rem;
+  padding: 0;
+}
+
+.category-list-item a {
+  color: black;
+  text-decoration: none;
+  font-size: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.category-list-item a:hover {
+  color: black;
+}
+
+.category-list-item img {
+  width: 50px;
+  height: 50px;
+}
+
+.category-list-item > a > div {
+  width: 50px;
+  height: 1px;
+  border-bottom: 2px solid gray;
+  margin: 0.4rem 0;
+  transform: scaleX(1);
+  transition: transform ease 0.1s;
+}
+
+.category-list-item > a:hover > div {
+  border-bottom: 2px solid $green;
+  transform: scaleX(2);
+}

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,4 +1,19 @@
 // Specific CSS for your home-page
+.home-container {
+  padding: 6rem;
+}
+
+.white-container {
+  background-color: white;
+}
+
+.green-container {
+  background-color: #F1FDF7;
+}
+
+.dark-blue-container {
+  background-color: #0D084D;
+}
 
 .trusted-by-wrapper {
   background-color: $light-gray;

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -2,8 +2,11 @@
 h2 {
   font-size: 2.2rem;
   font-weight: 600;
+  margin-bottom: 1.5rem;
 }
 
+
+// Style settings for containers in the home page.
 .home-container {
   padding: 6rem;
 }
@@ -24,6 +27,7 @@ h2 {
   background-color: $light-gray;
 }
 
+// Styles for trusted-by bar below top banner.
 .trusted-by {
   width: 800px;
   margin: 0 auto;
@@ -44,4 +48,27 @@ h2 {
   display: inline;
   margin: 0 0 0 3rem;
   padding: 0;
+}
+
+// Styles for category cards
+.category-cards {
+  display: flex;
+  justify-content: space-between;
+}
+
+.category-card {
+  color: white;
+  width: 230px;
+  height: 340px;
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+.category-card > h3 {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.category-card > h3 > small {
+  font-size: 1rem;
 }

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -128,16 +128,16 @@ h2 {
 
 // Style for category list section
 .category-list {
-  display: inline-block;
+  display: flex;
+  flex-wrap: wrap;
   list-style-type: none;
-  margin: 0;
-  padding: 0;
+  margin: 0 auto;
+  padding: 0 auto;
 }
 
 .category-list-item {
-  display: inline;
-  margin: 2rem;
-  padding: 0;
+  display: inline-block;
+  margin: 3.5rem;
 }
 
 .category-list-item a {

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -17,5 +17,5 @@
   </div>
 </div>
 <div class="home-container white-container">
-  <h1>Popular professional services</h1>
+  <h2>Popular professional services</h2>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -83,65 +83,65 @@
     </li>
     <li class="category-list-item">
       <a href="#">
-        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836462/Fiverr-Home/Category%20List/svg-2_prigee.svg">
         <div> </div>
-        Graphics & Design
+        Digital Marketing
       </a>
     </li>
     <li class="category-list-item">
       <a href="#">
-        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836462/Fiverr-Home/Category%20List/svg-3_mvjei7.svg">
         <div> </div>
-        Graphics & Design
+        Writing & Translation
       </a>
     </li>
     <li class="category-list-item">
       <a href="#">
-        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836462/Fiverr-Home/Category%20List/svg-4_njjs1n.svg">
         <div> </div>
-        Graphics & Design
+        Video & Animation
       </a>
     </li>
     <li class="category-list-item">
       <a href="#">
-        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836462/Fiverr-Home/Category%20List/svg-5_qjsrq9.svg">
         <div> </div>
-        Graphics & Design
+        Music & Audio
       </a>
     </li>
     <li class="category-list-item">
       <a href="#">
-        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-6_npvlmw.svg">
         <div> </div>
-        Graphics & Design
+        Programming & Tech
       </a>
     </li>
     <li class="category-list-item">
       <a href="#">
-        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-7_o1bmo3.svg">
         <div> </div>
-        Graphics & Design
+        Business
       </a>
     </li>
     <li class="category-list-item">
       <a href="#">
-        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-8_kg0ned.svg">
         <div> </div>
-        Graphics & Design
+        Style
       </a>
     </li>
     <li class="category-list-item">
       <a href="#">
-        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-9_nc3los.svg">
         <div> </div>
-        Graphics & Design
+        Data
       </a>
     </li>
     <li class="category-list-item">
       <a href="#">
-        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-10_t5yy60.svg">
         <div> </div>
-        Graphics & Design
+        Photography
       </a>
     </li>
   </ul>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -16,3 +16,6 @@
     </ul>
   </div>
 </div>
+<div class="home-container white-container">
+  <h1>Popular professional services</h1>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -70,3 +70,79 @@
     <a href="#" class="video-btn"><i class="fa-solid fa-play"></i></a>
   </div>
 </div>
+
+<div class="home-container white-container">
+  <h2>Explore the marketplace</h2>
+  <ul class="category-list">
+    <li class="category-list-item">
+      <a href="#">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <div> </div>
+        Graphics & Design
+      </a>
+    </li>
+    <li class="category-list-item">
+      <a href="#">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <div> </div>
+        Graphics & Design
+      </a>
+    </li>
+    <li class="category-list-item">
+      <a href="#">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <div> </div>
+        Graphics & Design
+      </a>
+    </li>
+    <li class="category-list-item">
+      <a href="#">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <div> </div>
+        Graphics & Design
+      </a>
+    </li>
+    <li class="category-list-item">
+      <a href="#">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <div> </div>
+        Graphics & Design
+      </a>
+    </li>
+    <li class="category-list-item">
+      <a href="#">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <div> </div>
+        Graphics & Design
+      </a>
+    </li>
+    <li class="category-list-item">
+      <a href="#">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <div> </div>
+        Graphics & Design
+      </a>
+    </li>
+    <li class="category-list-item">
+      <a href="#">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <div> </div>
+        Graphics & Design
+      </a>
+    </li>
+    <li class="category-list-item">
+      <a href="#">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <div> </div>
+        Graphics & Design
+      </a>
+    </li>
+    <li class="category-list-item">
+      <a href="#">
+        <img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678836460/Fiverr-Home/Category%20List/svg-1_winffz.svg">
+        <div> </div>
+        Graphics & Design
+      </a>
+    </li>
+  </ul>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -4,6 +4,7 @@
     <a class="btn btn-green fw-bold px-3 py-2" href="#">Join now</a>
   </div>
 </div>
+
 <div class="trusted-by-wrapper">
   <div class="trusted-by">
     <span>Trusted by:</span>
@@ -16,6 +17,7 @@
     </ul>
   </div>
 </div>
+
 <div class="home-container white-container">
   <h2>Popular professional services</h2>
   <div class="category-cards">
@@ -49,5 +51,22 @@
         Voice Over
       </h3>
     </div>
+  </div>
+</div>
+
+<div class="home-container green-container proposition-section">
+  <div class="proposition-card">
+    <h2>A whole world of freelance talent at your fingertips</h2>
+    <h3><span><i class="fa-regular fa-circle-check"></i></span> The best for every budget</h3>
+    <p>Find high-quality services at every price point. No hourly rates, just project-based pricing.</p>
+    <h3><span><i class="fa-regular fa-circle-check"></i></span> Quality work done quickly</h3>
+    <p>Find the right freelancer to begin working on your project within minutes.</p>
+    <h3><span><i class="fa-regular fa-circle-check"></i></span> Protected payments, every time</h3>
+    <p>Always know what you'll pay upfront. Your payment isn't released until you approve the work.</p>
+    <h3><span><i class="fa-regular fa-circle-check"></i></span> 24/7 support</h3>
+    <p>Questions? Our round-the-clock support team is available to help anytime, anywhere.</p>
+  </div>
+  <div class="proposition-video" style="background-image: url('https://res.cloudinary.com/dsx50recn/image/upload/v1678808296/Fiverr-Home/proposition-1_y1d71q.webp'); background-size: cover;">
+    <a href="#" class="video-btn"><i class="fa-solid fa-play"></i></a>
   </div>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -4,3 +4,15 @@
     <a class="btn btn-green fw-bold px-3 py-2" href="#">Join now</a>
   </div>
 </div>
+<div class="trusted-by-wrapper">
+  <div class="trusted-by">
+    <span>Trusted by:</span>
+    <ul>
+      <li><img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678801094/Fiverr-Home/trusted-1_b5pggl.png"></li>
+      <li><img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678801094/Fiverr-Home/trusted-2_p79mv2.png"></li>
+      <li><img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678801094/Fiverr-Home/trusted-3_rlbgx2.png"></li>
+      <li><img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678801094/Fiverr-Home/trusted-4_k19ooh.png"></li>
+      <li><img src="https://res.cloudinary.com/dsx50recn/image/upload/v1678801094/Fiverr-Home/trusted-5_cgqq1z.png"></li>
+    </ul>
+  </div>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -18,4 +18,36 @@
 </div>
 <div class="home-container white-container">
   <h2>Popular professional services</h2>
+  <div class="category-cards">
+    <div class="category-card" style="background-image: url('https://res.cloudinary.com/dsx50recn/image/upload/v1678800750/Fiverr-Home/services-1_sgf3an.webp'); background-size: cover;">
+      <h3>
+        <small>Customize your site</small>
+        WordPress
+      </h3>
+    </div>
+    <div class="category-card" style="background-image: url('https://res.cloudinary.com/dsx50recn/image/upload/v1678800750/Fiverr-Home/services-2_eolvlq.webp'); background-size: cover;">
+      <h3>
+        <small>Reach out more customers</small>
+        Social Media
+      </h3>
+    </div>
+    <div class="category-card" style="background-image: url('https://res.cloudinary.com/dsx50recn/image/upload/v1678800750/Fiverr-Home/services-3_egb5sj.webp'); background-size: cover;">
+      <h3>
+        <small>Build your brand</small>
+        Logo Design
+      </h3>
+    </div>
+    <div class="category-card" style="background-image: url('https://res.cloudinary.com/dsx50recn/image/upload/v1678800750/Fiverr-Home/services-4_mvpcut.webp'); background-size: cover;">
+      <h3>
+        <small>Add talent to AI</small>
+        AI Artists
+      </h3>
+    </div>
+    <div class="category-card" style="background-image: url('https://res.cloudinary.com/dsx50recn/image/upload/v1678800749/Fiverr-Home/services-5_p68gnw.webp'); background-size: cover;">
+      <h3>
+        <small>Share your message</small>
+        Voice Over
+      </h3>
+    </div>
+  </div>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,2 +1,6 @@
-<h1>Pages#home</h1>
-<p>Find me in app/views/pages/home.html.erb</p>
+<div class="banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url(https://res.cloudinary.com/dsx50recn/image/upload/v1678800695/Fiverr-Home/carousel-1_ryn9rb.webp);">
+  <div class="banner-container">
+    <h1>Find the perfect <em>freelance</em> services for your business</h1>
+    <a class="btn btn-green fw-bold px-3 py-2" href="#">Join now</a>
+  </div>
+</div>


### PR DESCRIPTION
# Description

Adds homepage at pages#home, which is the default landing page.
There is:
- a banner below the navbar,
- a section displaying services
- a section for proposition
- a section for categories listing

​
Fixes # (issue)
[https://trello.com/c/TjKW7wU5​](https://trello.com/c/TjKW7wU5)

## Type of change

​
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
      ​

# How Has This Been Tested?

- Top banner with a sub banner for trusted-by
![image](https://user-images.githubusercontent.com/81938708/225204655-56de9db1-c5ee-4168-aa89-d782019fd84d.png)

- Section listing services
![image](https://user-images.githubusercontent.com/81938708/225204930-a9ca6c3e-d7c6-4bd1-b3d3-6a171dba9dad.png)

- Proposition section
![image](https://user-images.githubusercontent.com/81938708/225205014-88e1972c-9d35-4ac4-811e-4771f5f8fc7b.png)

- Section listing categories
![image](https://user-images.githubusercontent.com/81938708/225205068-7e398772-62d4-41ad-9466-661532319e28.png)

      
# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
      Collapse
