### PR TITLE
Footer bugfix

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -3,9 +3,6 @@
   justify-content: space-between;
   text-align: center;
   padding: 4px;
-  position: absolute;
-  bottom: 0;
-  width: 100%;
   height: 60px;
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
-  <body>
+  <body class="min-vh-100 d-flex flex-column justify-content-start">
     <%= render "shared/navbar" %>
     <%= render "shared/flashes" %>
     <% if user_signed_in? %>
@@ -16,7 +16,7 @@
     <% else %>
       <%= link_to "Login", new_user_session_path, class: "btn btn-green" %>
     <% end %>
-    <div>
+    <div class="flex-grow-1">
       <%= yield %>
     </div>
     <%= render "shared/footer" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,12 +11,12 @@
   <body class="min-vh-100 d-flex flex-column justify-content-start">
     <%= render "shared/navbar" %>
     <%= render "shared/flashes" %>
-    <% if user_signed_in? %>
-      <%= link_to 'Logout', destroy_user_session_path, data: {turbo_method: :delete}, class: "btn btn-transparent-green" %>
-    <% else %>
-      <%= link_to "Login", new_user_session_path, class: "btn btn-green" %>
-    <% end %>
     <div class="flex-grow-1">
+      <% if user_signed_in? %>
+        <%= link_to 'Logout', destroy_user_session_path, data: {turbo_method: :delete}, class: "btn btn-transparent-green" %>
+      <% else %>
+        <%= link_to "Login", new_user_session_path, class: "btn btn-green" %>
+      <% end %>
       <%= yield %>
     </div>
     <%= render "shared/footer" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,9 @@
     <% else %>
       <%= link_to "Login", new_user_session_path, class: "btn btn-green" %>
     <% end %>
-    <%= yield %>
+    <div>
+      <%= yield %>
+    </div>
     <%= render "shared/footer" %>
   </body>
 </html>


### PR DESCRIPTION
# Description

Bug-fixed the footer to fix the footer to the bottom of the page instead of bottom of the screen. The footer will now be fixed to the bottom of the page when the page is more or less than the viewport height.
​
Fixes # 
https://trello.com/c/43jIzvfX
​

## Type of change

​
Please delete options that are not relevant.
​
- [x] Bug fix (non-breaking change which fixes an issue)
      ​

# How Has This Been Tested?
[ ] Footer is at the bottom of the page for a page that is less than 100% viewport height
<img width="1440" alt="Screenshot 2023-03-15 at 12 25 59 PM" src="https://user-images.githubusercontent.com/118903492/225206361-66dc661f-9322-4b7c-909e-c216c14add04.png">

- [x] Footer is not shown when the page is more than 100% viewport height but shows up at the very bottom of the page
<img width="1440" alt="Screenshot 2023-03-15 at 12 26 48 PM" src="https://user-images.githubusercontent.com/118903492/225206444-9f4d0389-cd90-4f5d-8664-072c7502831d.png">
<img width="1440" alt="Screenshot 2023-03-15 at 12 26 58 PM" src="https://user-images.githubusercontent.com/118903492/225206472-3104ada9-7f0b-4bea-b6e0-b17a4abc7026.png">

      
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
      Collapse
