### PR TITLE
uses image URL for default photos instead of cloudinary keys

### DIFF
--- a/app/views/services/_service-details.html.erb
+++ b/app/views/services/_service-details.html.erb
@@ -1,6 +1,10 @@
 <div class="service-intro m-4">
   <h1 class="mb-4"><%= @service.title %></h1>
-  <%= cl_image_tag @service.photo.key ? @service.photo.key : ('g9j2kjmajzgz1en4j20h42h3e8w3'), class: "mb-4", height: 450, width: 700, crop: :fill %>
+  <% if @service.photo.key%>
+    <%= cl_image_tag @service.photo.key, class: "mb-4", height: 450, width: 700, crop: :fill %>
+  <% else %>
+    <%= image_tag('https://res.cloudinary.com/drftmp0s5/image/upload/v1678852787/development/g9j2kjmajzgz1en4j20h42h3e8w3.jpg', height: 450, width: 700) %>
+  <% end %>
 </div>
 <div class="service-description m-4 border-bottom">
   <h2>About This Gig</h2>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -19,7 +19,13 @@
       </li>
       <% if current_user %>
         <li class="nav-item">
-          <a class="nav-link" href="/users/<%= current_user.id %>"><%= cl_image_tag current_user.photo.key ? current_user.photo.key : ("tg9fkn8640h57hawm7qlaxuj1a46"), class: 'avatar-xs' %></a>
+          <a class="nav-link" href="/users/<%= current_user.id %>">
+            <% if current_user.photo.key%>
+              <%= cl_image_tag current_user.photo.key, class: 'avatar-xs' %>
+            <% else %>
+              <%= image_tag('https://res.cloudinary.com/drftmp0s5/image/upload/v1678852728/development/eikdtlh3ky8vfdi8cm216xts79e9.jpg', class: 'avatar-xs') %>
+            <% end %>
+          </a>
         </li>
       <% end %>
       <% if user_signed_in? %>

--- a/app/views/users/_card-profile.html.erb
+++ b/app/views/users/_card-profile.html.erb
@@ -6,7 +6,11 @@
         <i class="fa-solid fa-heart"></i>
       </div>
       <div class="img-wrapper">
-        <%= cl_image_tag @user.photo.key ? @user.photo.key : ('tg9fkn8640h57hawm7qlaxuj1a46'), class: 'avatar-xl' %>
+        <% if current_user.photo.key%>
+          <%= cl_image_tag @user.photo.key, class: 'avatar-xl' %>
+        <% else %>
+          <%= image_tag('https://res.cloudinary.com/drftmp0s5/image/upload/v1678852728/development/eikdtlh3ky8vfdi8cm216xts79e9.jpg', class: 'avatar-xl') %>
+        <% end %>
         <p class='text-center pt-2'><%= @user.username %></p>
       </div>
       <div>

--- a/app/views/users/_service_card.html.erb
+++ b/app/views/users/_service_card.html.erb
@@ -6,7 +6,11 @@
   <% end %>
   <div class="card-body">
     <div class='pb-2'>
-      <%= cl_image_tag user.photo.key ? user.photo.key : ('tg9fkn8640h57hawm7qlaxuj1a46'), class: 'avatar-xs' %>
+      <% if current_user.photo.key%>
+        <%= cl_image_tag user.photo.key, class: 'avatar-xs' %>
+      <% else %>
+        <%= image_tag('https://res.cloudinary.com/drftmp0s5/image/upload/v1678852728/development/eikdtlh3ky8vfdi8cm216xts79e9.jpg', class: 'avatar-xs') %>
+      <% end %>
       <span><%= user.username %></span>
     </div>
     <p class="card-text"><%= service.title %></p>

--- a/app/views/users/_service_card.html.erb
+++ b/app/views/users/_service_card.html.erb
@@ -1,5 +1,9 @@
 <div class="card">
-  <%= cl_image_tag service.photo.key ? service.photo.key : ('g9j2kjmajzgz1en4j20h42h3e8w3'), class: 'card-img-top'%>
+  <% if service.photo.key%>
+    <%= cl_image_tag service.photo.key, class: "mb-4", height: 450, width: 700, crop: :fill %>
+  <% else %>
+    <%= image_tag('https://res.cloudinary.com/drftmp0s5/image/upload/v1678852787/development/g9j2kjmajzgz1en4j20h42h3e8w3.jpg', class: 'card-img-top') %>
+  <% end %>
   <div class="card-body">
     <div class='pb-2'>
       <%= cl_image_tag user.photo.key ? user.photo.key : ('tg9fkn8640h57hawm7qlaxuj1a46'), class: 'avatar-xs' %>


### PR DESCRIPTION
# Description
Adds default photos for user avatars, and service photos
Uses image URL instead of cloudinary Key.
​
Fixes # (issue)
default ​photos were not rendering on heroku.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
​
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
​
I have tested it by creating a new account and new services on my local machine but I need to merge to master  and deploy before I can test on heroku

      
# Checklist:
​
- [x] I have performed a self-review of my code
