### PR TITLE
Standardises service card height, and deals with overflow text from service title

### DIFF
--- a/app/assets/stylesheets/components/_service-card.scss
+++ b/app/assets/stylesheets/components/_service-card.scss
@@ -15,19 +15,24 @@
 
 .service-card #price{
   font-size: 22px;
-
 }
 
 .card-content {
   display: flex;
   flex-direction: column;
   min-height: 150px;
+
 }
 
 .card-body {
   height: 100px;
-  white-space: wrap;
+}
+
+.card-text {
   overflow: hidden;
   text-overflow: ellipsis;
-
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  padding-right: 15px;
 }

--- a/app/assets/stylesheets/components/_service-card.scss
+++ b/app/assets/stylesheets/components/_service-card.scss
@@ -1,3 +1,9 @@
+
+
+.card-img-top {
+  height: 200px;
+  object-fit: cover;
+}
 .service-card {
   position: sticky;
   top: 40px;
@@ -9,4 +15,19 @@
 
 .service-card #price{
   font-size: 22px;
+
+}
+
+.card-content {
+  display: flex;
+  flex-direction: column;
+  min-height: 150px;
+}
+
+.card-body {
+  height: 100px;
+  white-space: wrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
 }

--- a/app/views/users/_service_card.html.erb
+++ b/app/views/users/_service_card.html.erb
@@ -1,11 +1,12 @@
 <div class="card">
-  <a href=<%= service_path(service) %>>
-     <% if service.photo.key%>
-    <%= cl_image_tag service.photo.key, class: "mb-4", class: 'card-img-top' %>
-  <% else %>
-    <%= image_tag('https://res.cloudinary.com/drftmp0s5/image/upload/v1678852787/development/g9j2kjmajzgz1en4j20h42h3e8w3.jpg', class: 'card-img-top') %>
+  <%= link_to service_path(service) do %>
+    <% if service.photo.key%>
+      <%= cl_image_tag service.photo.key, class: 'card-img-top' %>
+    <% else %>
+      <%= image_tag('https://res.cloudinary.com/drftmp0s5/image/upload/v1678852787/development/g9j2kjmajzgz1en4j20h42h3e8w3.jpg', class: 'card-img-top') %>
+    <% end %>
   <% end %>
-  </a>
+  <div class="card-content">
     <div class="card-body">
       <div class='pb-2'>
         <% if user.photo.key%>
@@ -15,8 +16,8 @@
         <% end %>
         <a class="text-decoration-none text-dark" href=<%= user_path(user) %> ><%= user.username %></a>
       </div>
-      <a class="text-decoration-none text-dark"href=<%= service_path(service) %>>
-      <p class="card-text"><%= service.title %></p>
+      <a class="text-decoration-none text-dark" href=<%= service_path(service) %>>
+        <p class="card-text"><%= service.title %></p>
       </a>
     </div>
     <ul class="list-group list-group-flush">
@@ -32,3 +33,4 @@
       </li>
     </ul>
   </div>
+</div>


### PR DESCRIPTION
# Description

Edits the service card partial & scss file so that:
1. Image on service card now all uniform height
2. Sets height for card text content as well so that all cards are same height regardless of title length
3. Deals with overflow of title length - allows 2 lines and then overflow has ellipsis (...)

​
Fixes # (issue)
​https://trello.com/c/2BmWoYGG

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
      ​
# How Has This Been Tested?

- [ ] Screenshot A​ - on service index page. example of ellipsis
<img width="1331" alt="Screenshot 2023-03-15 at 9 57 51 PM" src="https://user-images.githubusercontent.com/99415923/225332657-27ac14a5-2899-42e8-b83a-73e43baa9341.png">

- [ ] Screenshot B - services listed on user show page
<img width="894" alt="Screenshot 2023-03-15 at 9 58 13 PM" src="https://user-images.githubusercontent.com/99415923/225332662-e54795fa-55b7-467f-959f-524e8501d6f5.png">


# Checklist:
​
- [ ] I have performed a self-review of my code
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
      Collapse
