### PR TITLE
#country instance method on User model to convert country code from country_select gem

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,9 @@ class User < ApplicationRecord
   def username
     email.split('@').first
   end
+
+  def country
+    country = ISO3166::Country[location]
+    country.translations[I18n.locale.to_s] || country.name
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,9 @@ class User < ApplicationRecord
   end
 
   def country
-    country = ISO3166::Country[location]
-    country.translations[I18n.locale.to_s] || country.name
+    country_name = ISO3166::Country[location]
+    return location unless country_name
+
+    country_name.translations[I18n.locale.to_s]
   end
 end

--- a/app/views/services/_service-details.html.erb
+++ b/app/views/services/_service-details.html.erb
@@ -29,7 +29,7 @@
     <div class="seller-details border d-flex flex-wrap justify-content-between gap-3 m-1 p-4">
       <ul class="from mt-3">
         <li>From</li>
-        <li><strong><%= @service.seller.location %></strong></li>
+        <li><strong><%= @service.seller.country %></strong></li>
       </ul>
       <ul class="member-since mt-3">
         <li>Member since</li>

--- a/app/views/users/_card-profile.html.erb
+++ b/app/views/users/_card-profile.html.erb
@@ -25,7 +25,7 @@
   <div class='btn btn-green w-100'>Contact Me</div>
   <div class="user-stats-wrapper">
     <ul class='user-stats'>
-      <li><span><i class="fa-sharp fa-solid fa-location-dot"></i> From</span> <strong><%= @user.location %></strong></li>
+      <li><span><i class="fa-sharp fa-solid fa-location-dot"></i> From</span> <strong><%= @user.country %></strong></li>
       <li><span><i class="fa-solid fa-user"></i> Member since</span> <strong><%= @month_created %> <%= @user.created_at.year %></strong></li>
       <li><span><i class="fa-regular fa-clock"></i> Avg. Response Time</span></li>
     </ul>


### PR DESCRIPTION
# Description
1. Country_select gem returns a country code.
2. Created new instance method #country in User model.
3. Transforms country code (if required), otherwise returns location
4. Changes @user.location to @user.country in user profile page.

​
Fixes # (issue)
​https://trello.com/c/EHMpgu9b

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)      ​

# How Has This Been Tested?

- [ ] Screenshot A​ - now renders country name instead of country code as User's location
<img width="390" alt="Screenshot 2023-03-15 at 10 26 48 PM" src="https://user-images.githubusercontent.com/99415923/225339949-26504947-fe96-4872-abe7-37bd4f09b44b.png">

- [ ] Screenshot B - also renders in seller info at bottom of services show page
<img width="674" alt="Screenshot 2023-03-15 at 10 38 01 PM" src="https://user-images.githubusercontent.com/99415923/225343844-2f1bd5de-bfc9-487f-b4ce-666847eccf8d.png">

  
# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
      Collapse
