### PR TITLE
adds image upload field to new gig form

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -26,6 +26,6 @@ class ServicesController < ApplicationController
   private
 
   def service_params
-    params.require(:service).permit(:title, :description, :category, :price, :delivery_time)
+    params.require(:service).permit(:title, :description, :category, :price, :delivery_time, :photo)
   end
 end

--- a/app/views/services/_form.html.erb
+++ b/app/views/services/_form.html.erb
@@ -4,5 +4,6 @@
   <%= f.input :category, as: :select, collection: ['Graphics & Design', 'Digital Marketing', 'Writing & Translation', 'Video & Animation'], selected: "Graphics & Design" %>
   <%= f.input :price, label: 'Price', placeholder: '$ (SGD)' %>
   <%= f.input :delivery_time, label: 'Delivery time (days)', placeholder: 'Enter a number from 1 to 90' %>
+  <%= f.input :photo, as: :file %>
   <%= f.submit 'Create Gig', class: 'btn btn-green' %>
 <% end %>


### PR DESCRIPTION
# Description
Allows seller to attach an image when they are creating a new service.
​
Fixes # (issue)
https://trello.com/c/n9QWty8f
​

## Type of change
​
- [ ] New feature (non-breaking change which adds functionality)

      
# How Has This Been Tested?

​
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
​

- [ ] Screenshot A - image upload field in form
<img width="817" alt="Screenshot 2023-03-16 at 11 23 13 AM" src="https://user-images.githubusercontent.com/99415923/225505596-af2d39cb-fbb5-4932-8dec-ab5962772260.png">

- [ ] Screenshot B - successful uploading + rendering of image on service show page.
<img width="762" alt="Screenshot 2023-03-16 at 11 22 50 AM" src="https://user-images.githubusercontent.com/99415923/225505551-c72fce2e-b0c6-42ca-bee5-629e43c98217.png">

      ​

# Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
      Collapse
