### PR TITLE
Fixed navbar and footer bug on offers/new and added additional features

### DIFF
--- a/app/assets/stylesheets/pages/_offers-new.scss
+++ b/app/assets/stylesheets/pages/_offers-new.scss
@@ -48,3 +48,7 @@ form label{
 .radio {
   margin-top: 10px;
 }
+
+#offers-new .d-block{
+  color: grey;
+}

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -15,6 +15,9 @@ class OffersController < ApplicationController
 
     if @offer.save
       redirect_to service_path(@service), notice: "Offer was successfully created"
+    elsif @offer.valid? == false
+      # raise
+      redirect_to new_service_offer_path(@service), alert: "You already have this package"
     else
       render :new, status: :unprocessable_entity, alert: "Please fill in the required field"
     end

--- a/app/views/offers/new.html.erb
+++ b/app/views/offers/new.html.erb
@@ -1,6 +1,7 @@
 <div id="offers-new" class="container mt-5">
   <div class="row">
     <div class="col-7">
+      <%= link_to "< Back", service_path(@service),  class: "d-block pb-4 text-decoration-none" %>
       <%= render "payment-window" %>
     </div>
     <div class="col-1"></div>


### PR DESCRIPTION
# Description

Nav bar and footer no longer appears when @offer.valid? == false due to uniqueness validation. Instead, used an alert to notify user that they have already purchased this package. 

_note: had to use redirect_to instead of render :new. idk why :"))_

Also added a back function (goes back to service/:id) on the offers.new page
​
Fixes # (issue)

​Nav bar and footer no longer appears when @offer.valid? == false due to uniqueness validation. 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

      ​

# How Has This Been Tested?


- [x] Alert

<img width="1434" alt="Screenshot 2023-03-16 at 12 21 45 PM" src="https://user-images.githubusercontent.com/123570606/225513641-236b814b-6cc8-4b6f-bc73-c92ab16dd793.png">

- [x] New Back Function
      ​
<img width="439" alt="Screenshot 2023-03-16 at 12 22 14 PM" src="https://user-images.githubusercontent.com/123570606/225513724-ea16985c-0be3-4fc5-bd22-07000dc33575.png">

# Checklist:

- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
      Collapse
