### PR TITLE
adds height to make avatar image circular

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -1,30 +1,41 @@
 .avatar {
   width: 40px;
   border-radius: 50%;
+  object-fit: cover;
 }
 .avatar-large {
   width: 56px;
+  height: 56px;
   border-radius: 50%;
+  object-fit: cover;
 }
 .avatar-bordered {
   width: 40px;
+  height: 40px;
   border-radius: 50%;
   box-shadow: 0 1px 2px rgba(0,0,0,0.2);
   border: white 1px solid;
+  object-fit: cover;
 }
 .avatar-square {
   width: 40px;
+  height: 40px;
   border-radius: 0px;
   box-shadow: 0 1px 2px rgba(0,0,0,0.2);
   border: white 1px solid;
+  object-fit: cover;
 }
 
 .avatar-xl {
   width: 150px;
+  height: 150px;
+  object-fit: cover;
   border-radius: 50%;
 }
 
 .avatar-xs {
   width: 24px;
+  height: 24px;
   border-radius: 50%;
+  object-fit: cover;
 }


### PR DESCRIPTION
# Description

includes height that matches width so that avatar is circle 
​
Fixes # (issue)
​https://trello.com/c/UVAUWyp5

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
      ​

# How Has This Been Tested?

- [x] Screenshot A​ - circular avatar from landscape image.

<img width="342" alt="Screenshot 2023-03-17 at 12 18 56 PM" src="https://user-images.githubusercontent.com/99415923/225811892-93aac8f8-7fff-4c09-b44b-ac886890c9eb.png">

​

# Checklist:


- [x] I have performed a self-review of my code
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
      Collapse
