### PR TITLE
redirects after authentication to the last page they were on

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :store_user_location!, if: :storable_location?
   before_action :authenticate_user!
   include Pundit::Authorization
 
@@ -22,21 +23,30 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update, keys: [:location, :photo])
   end
 
-  def after_sign_in_path_for(resource)
-    root_path
+  def after_sign_in_path_for(resource_or_scope)
+    stored_location_for(resource_or_scope) || super
   end
 
   def after_sign_out_path_for(resource)
     root_path
   end
 
-  def after_sign_up_path_for(resource)
-    root_path
+  def after_sign_up_path_for(resource_or_scope)
+    stored_location_for(resource_or_scope) || super
   end
 
   private
 
   def skip_pundit?
     devise_controller? || params[:controller] =~ /(^(rails_)?admin)|(^pages$)/
+  end
+
+  def storable_location?
+    request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
+  end
+
+  def store_user_location!
+    # :user is the scope we are authenticating
+    store_location_for(:user, request.fullpath)
   end
 end


### PR DESCRIPTION
# Description
Redirects user to the page that they're trying to visit after authentication, instead of always returning to home page by default.
creates new methods storable_location? and store_user_location! in application controller, and overrides #after_sign_in_path and #after_sign_up_path  to use stored location

Fixes # (issue)
https://trello.com/c/RirnFqJE​

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

      
# How Has This Been Tested?
tested on local machine, routes correctly​
creates new methods in application controllerp
<img width="757" alt="Screenshot 2023-03-17 at 2 05 25 PM" src="https://user-images.githubusercontent.com/99415923/225825590-551c7c63-3e97-42bb-b16d-3545a8cbc4ea.png">

# Checklist:


- [x] I have performed a self-review of my code
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
      Collapse
